### PR TITLE
Fix: do not grant ex-member role if user still has an account in any clan

### DIFF
--- a/src/main/java/lostmanager/commands/coc/memberlist/removemember.java
+++ b/src/main/java/lostmanager/commands/coc/memberlist/removemember.java
@@ -121,8 +121,11 @@ public class removemember extends ListenerAdapter {
 			boolean b = false;
 			// Note: hiddencoleaders should not count as elder or higher
 			boolean otherElderOrHigherSameClan = false;
+			// Whether the user still has any linked account in any clan
+			boolean inAnyClan = false;
 			for (Player acc : allaccs) {
 				if (acc.getClanDB() != null) {
+					inAnyClan = true;
 					if (acc.getClanDB().getTag().equals(clantag)) {
 						b = true;
 						if (Player.isElderOrHigher(acc.getRoleDB()) && !acc.isHiddenColeader()) {
@@ -181,7 +184,10 @@ public class removemember extends ListenerAdapter {
 			String exmemberroleid = Bot.exmember_roleid;
 			Role exmemberrole = guild.getRoleById(exmemberroleid);
 			if (exmemberrole != null) {
-				if (member.getRoles().contains(exmemberrole)) {
+				if (inAnyClan) {
+					desc += "\n\n**Der User <@" + userid
+							+ "> hat noch mindestens einen Account in einem Clan, daher wurde ihm die Ex-Member-Rolle nicht hinzugefügt.**";
+				} else if (member.getRoles().contains(exmemberrole)) {
 					desc += "\n\n";
 					desc += "**Der User <@" + userid + "> hat die Rolle <@&" + exmemberroleid + "> bereits.**\n";
 				} else {

--- a/src/main/java/lostmanager/webserver/api/ManagementApiHandler.java
+++ b/src/main/java/lostmanager/webserver/api/ManagementApiHandler.java
@@ -395,11 +395,16 @@ public class ManagementApiHandler implements HttpHandler {
 				ArrayList<Player> allaccs = player.getUser().getAllLinkedAccounts();
 				boolean hasOtherAccInClan = false;
 				boolean otherElderOrHigherSameClan = false;
+				// Whether the user still has any linked account in any clan
+				boolean inAnyClan = false;
 				for (Player acc : allaccs) {
-					if (acc.getClanDB() != null && acc.getClanDB().getTag().equals(clanTag)) {
-						hasOtherAccInClan = true;
-						if (Player.isElderOrHigher(acc.getRoleDB()) && !acc.isHiddenColeader()) {
-							otherElderOrHigherSameClan = true;
+					if (acc.getClanDB() != null) {
+						inAnyClan = true;
+						if (acc.getClanDB().getTag().equals(clanTag)) {
+							hasOtherAccInClan = true;
+							if (Player.isElderOrHigher(acc.getRoleDB()) && !acc.isHiddenColeader()) {
+								otherElderOrHigherSameClan = true;
+							}
 						}
 					}
 				}
@@ -423,7 +428,7 @@ public class ManagementApiHandler implements HttpHandler {
 
 				String exmemberroleid = Bot.exmember_roleid;
 				Role exmemberrole = exmemberroleid != null ? guild.getRoleById(exmemberroleid) : null;
-				if (exmemberrole != null && !member.getRoles().contains(exmemberrole)) {
+				if (exmemberrole != null && !inAnyClan && !member.getRoles().contains(exmemberrole)) {
 					guild.addRoleToMember(member, exmemberrole).queue();
 					roleChanges.put(new JSONObject().put("type", "added")
 							.put("roleId", exmemberroleid).put("userId", userid));


### PR DESCRIPTION
The ex-member role was granted on member removal even when the user
still had a linked account in another clan. Both the removemember
slash command and the management API now check whether any linked
account remains in any clan and skip granting the ex-member role in
that case.